### PR TITLE
Precompile assets before build and clean up after for Rails apps

### DIFF
--- a/master-builder.groovy
+++ b/master-builder.groovy
@@ -125,6 +125,7 @@ source /var/lib/jenkins/env
 [[ -s 'package.json' ]] && npm install
 [[ -s 'Gemfile' ]] && bundle --without=production
 [[ -s 'db' ]] && rake db:migrate
+[[ -s 'app/assets' ]] && rake assets:precompile
 rake --trace""")
         }
 
@@ -173,6 +174,26 @@ git push origin --tags --force"""
 source "/var/lib/jenkins/.rvm/scripts/rvm" && rvm use .
 [[ -s 'features' ]] && bundle exec relish push theodi/${projectName}"""
                 }
+              }
+            }
+          }
+          
+          // Clean up assets after build
+          project/publishers << "hudson.plugins.postbuildtask.PostbuildTask" {
+            tasks {
+              "hudson.plugins.postbuildtask.TaskProperties" {
+                logTexts {
+                  "hudson.plugins.postbuildtask.LogProperties" {
+                    logText ""
+                    operator "AND"
+                  }
+                }
+                "EscalateStatus" "false"
+                "RunIfJobSuccessful" "false"
+                script """\
+#!/bin/bash
+source "/var/lib/jenkins/.rvm/scripts/rvm" && rvm use .
+[[ -s 'app/assets' ]] && rake assets:clean"""
               }
             }
           }          


### PR DESCRIPTION
This should mean builds fail if we have assets that aren't correctly precompiled. At the moment, it's too easy to get broken stuff going into production.

This does require an extra step in the app itself (mainly adding an initializer and an ENV variable into Jenkins), but if it's not there, things won't break.
