### PR TITLE
don't bundle development gems

### DIFF
--- a/master-builder.groovy
+++ b/master-builder.groovy
@@ -135,7 +135,7 @@ projects.each {
 export LANG=en_US.UTF-8
 source /var/lib/jenkins/env
 [[ -s 'package.json' ]] && npm install
-[[ -s 'Gemfile' ]] && bundle --without=production
+[[ -s 'Gemfile' ]] && bundle --without=production:development
 [[ -s 'db' ]] && rake db:migrate
 [[ -s 'app/assets' ]] && RAILS_ENV=development bundle exec rake assets:precompile
 rake --trace""")


### PR DESCRIPTION
I noticed that jenkins was installing gems in our development bundler group - I guess these shouldn't be installed?
